### PR TITLE
Fixed mql4Define of #property and detect *.mqh files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ How to add mql4 syntax file into your vim configuration:
 
 
     $ mkdir -p ~/.vim/ftdetect
-    $ echo 'au BufRead,BufNewFile *.mq4		set filetype=mql4' > ~/.vim/ftdetect/mql4.vim
+    $ echo 'au BufRead,BufNewFile *.mq[4h]		set filetype=mql4' > ~/.vim/ftdetect/mql4.vim
     $ mkdir -p ~/.vim/syntax 
     $ cd ~/.vim/syntax
     $ wget https://github.com/vobornik/vim-mql4/raw/master/mql4.vim

--- a/mql4.vim
+++ b/mql4.vim
@@ -169,7 +169,7 @@ syn match       mql4Operator       "\(&&\|||\|==\|!=\|<\|>\|<=\|>=\)"
 
 syn match       mql4Define         "#import"
 syn match       mql4Define         "#define"
-syn match       mql4Define         "#property\s\+\(copyright\|link\|stacksize\|library\|indicator_chart_window\|indicator_separate_window\|indicator_buffers\|indicator_minimum\|indicator_maximum\|indicator_color[1-8]\|indicator_width\[1-8\]\|indicator_style\[1-8\]\|indicator_level\[1-8\]\|indicator_levelcolor\|indicator_levelwidth\|indicator_levelstyle\|show_confirm\|show_inputs\)\(\s\+\|$\)"
+syn match       mql4Define         "#property\s\+\(copyright\|link\|stacksize\|library\|indicator_chart_window\|indicator_separate_window\|indicator_buffers\|indicator_minimum\|indicator_maximum\|indicator_color[1-8]\|indicator_width[1-8]\|indicator_style[1-8]\|indicator_level[1-8]\|indicator_levelcolor\|indicator_levelwidth\|indicator_levelstyle\|show_confirm\|show_inputs\)\(\s\+\|$\)"
 
 syn keyword	mql4Type		bool color datetime double int string void
 


### PR DESCRIPTION
There is syntax error in `syn match mql4Define` line for `#property`. The set `[1-8]` should not be escaped like `\[1-8\]`.

I have just removed only unneeded backslash characters.

I have added support for `*.mqh` files to the **QUICK HOWTO** section in `README.md` file.
